### PR TITLE
Fixes for CUPS-2.2.4

### DIFF
--- a/aps/Makefile
+++ b/aps/Makefile
@@ -38,11 +38,12 @@ clean:
 	$(RM) *.o *~ $(TARGETS)
 
 install:
-	$(INSTALL) libaps.a $(libdir)
-	$(INSTALL) -d $(includedir)/aps
-	$(INSTALL) -m 644 models.def version.def aps.h version.h $(includedir)/aps
+	mkdir -p $(DESTDIR)$(libdir)
+	$(INSTALL) libaps.a $(DESTDIR)$(libdir)
+	$(INSTALL) -d $(DESTDIR)$(includedir)/aps
+	$(INSTALL) -m 644 models.def version.def aps.h version.h $(DESTDIR)$(includedir)/aps
 
 uninstall:
-	$(RM) $(libdir)/libaps.a
-	$(RM) -r $(includedir)/aps
+	$(RM) $(DESTDIR)$(libdir)/libaps.a
+	$(RM) -r $(DESTDIR)$(includedir)/aps
 

--- a/cups/Makefile
+++ b/cups/Makefile
@@ -36,14 +36,15 @@ clean:
 	@$(RM) *.o $(TARGETS)
 
 install:
-	@$(INSTALL) -s aps $(backenddir)
+	mkdir -p $(DESTDIR)$(backenddir) $(DESTDIR)$(filterdir)
+	@$(INSTALL) -s aps $(DESTDIR)$(backenddir)
 #	@$(INSTALL) -s utf8toaps $(filterdir)
-	@$(INSTALL) -s rastertoaps $(filterdir)
-	@$(INSTALL) -s texttoaps $(filterdir)
+	@$(INSTALL) -s rastertoaps $(DESTDIR)$(filterdir)
+	@$(INSTALL) -s texttoaps $(DESTDIR)$(filterdir)
 	
 uninstall:
-	@$(RM) $(backenddir)/aps
-	@$(RM) $(filterdir)/rastertoaps
-	@$(RM) $(filterdir)/texttoaps
+	@$(RM) $(DESTDIR)$(backenddir)/aps
+	@$(RM) $(DESTDIR)$(filterdir)/rastertoaps
+	@$(RM) $(DESTDIR)$(filterdir)/texttoaps
 #	@$(RM) $(filterdir)/utf8toaps
 

--- a/cups/options.c
+++ b/cups/options.c
@@ -42,6 +42,7 @@
 #include <signal.h>
 
 #include <cups/cups.h>
+#include <cups/ppd.h>
 #include <cups/raster.h>
 
 #include <aps/aps.h>

--- a/drv/Makefile
+++ b/drv/Makefile
@@ -50,15 +50,16 @@ purge_ppd:
 
 install:
 	@echo "Install PPD files ..."
+	@mkdir -p $(DESTDIR)$(modeldir)
 	@for model in $(models); do\
 		echo Installing printer model $$model... ;\
-		$(INSTALL) -m 644 $(ppddir)/$$model $(modeldir) || exit 1;\
+		$(INSTALL) -m 644 $(ppddir)/$$model $(DESTDIR)$(modeldir) || exit 1;\
 	done
 
 uninstall:
 	@echo "Unrinstall PPD files ..."
 	@for model in $(models); do\
 		echo Uninstalling printer model $$model... ;\
-		$(RM) $(modeldir)/$$model ;\
+		$(RM) $(DESTDIR)$(modeldir)/$$model ;\
 	done
 


### PR DESCRIPTION
I tried to build the APS Linux Driver 0.16 for an ARMv7a embedded system running CUPS 2.2.4, and it wouldn't compile out-of-the-box. Here is the patch which contains the necessary changes so it builds correctly, as well as some other nice-to-have functionality.